### PR TITLE
Configure Prometheus to collect metrics from HAProxy

### DIFF
--- a/dfaasagent/agent/loadbalancer/haproxycfgnms.tmpl
+++ b/dfaasagent/agent/loadbalancer/haproxycfgnms.tmpl
@@ -1,7 +1,7 @@
 # HAProxy configuration file updated by DFaaS agent on {{.Now}}
 
 # See k8s/charts/values-haproxy.yaml for more information about global,
-# userlist, defaults and program sections.
+# userlist, defaults, and prometheus frontend sections.
 global
   master-worker no-exit-on-failure
   stats socket /var/run/haproxy.sock mode 660 level admin expose-fd listeners
@@ -19,6 +19,12 @@ defaults
   timeout client 60s
   timeout connect 60s
   timeout server 60s
+
+frontend prometheus
+  bind :8405
+  mode http
+  http-request use-service prometheus-exporter
+  no log
 
 # The configuration is generated and changed by the DFaaS agent from this point
 # on.

--- a/dfaasagent/agent/loadbalancer/haproxycfgrecalc.tmpl
+++ b/dfaasagent/agent/loadbalancer/haproxycfgrecalc.tmpl
@@ -2,7 +2,7 @@
 # DFaaS Agent running with Recalc strategy.
 
 # See k8s/charts/values-haproxy.yaml for more information about global,
-# userlist, defaults and program sections.
+# userlist, defaults, and prometheus frontend sections.
 global
   master-worker no-exit-on-failure
   stats socket /var/run/haproxy.sock mode 660 level admin expose-fd listeners
@@ -20,6 +20,12 @@ defaults
   timeout client 60s
   timeout connect 60s
   timeout server 60s
+
+frontend prometheus
+  bind :8405
+  mode http
+  http-request use-service prometheus-exporter
+  no log
 
 {{range $funcName, $func := .Functions -}}
 # Stick table for invocations of function {{$funcName}} from users, not from

--- a/dfaasagent/agent/loadbalancer/haproxycfgstatic.tmpl
+++ b/dfaasagent/agent/loadbalancer/haproxycfgstatic.tmpl
@@ -2,7 +2,7 @@
 # DFaaS Agent running with Static strategy.
 
 # See k8s/charts/values-haproxy.yaml for more information about global,
-# userlist, defaults and program sections.
+# userlist, defaults, and prometheus frontend sections.
 global
   master-worker no-exit-on-failure
   stats socket /var/run/haproxy.sock mode 660 level admin expose-fd listeners
@@ -20,6 +20,12 @@ defaults
   timeout client 60s
   timeout connect 60s
   timeout server 60s
+
+frontend prometheus
+  bind :8405
+  mode http
+  http-request use-service prometheus-exporter
+  no log
 
 # The configuration is generated and changed by the DFaaS agent from this point
 # on.

--- a/k8s/charts/values-haproxy.yaml
+++ b/k8s/charts/values-haproxy.yaml
@@ -120,6 +120,12 @@ args:
 service:
   type: NodePort
 
+  # Let Prometheus to automatically scrape HAProxy metrics.
+  # See: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus#scraping-pod-metrics-via-annotations
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8405"
+
   # Map each container port to a specific node port for external access (from
   # outside the cluster). We do not intend to expose the Prometheus port, but
   # Kubernetes will still map it to a random node port regardless.

--- a/k8s/charts/values-haproxy.yaml
+++ b/k8s/charts/values-haproxy.yaml
@@ -7,7 +7,7 @@
 # API process to run. This means that we run multiple processes in a single
 # container. While this is not ideal for Kubernetes, DFaaS is a prototype.
 #
-# Copyright 2025 The DFaaS Authors. All rights reserved.
+# Copyright 2025-2026 The DFaaS Authors. All rights reserved.
 # This file is licensed under the AGPL v3.0 or later license. See LICENSE and
 # AUTHORS file for more information.
 
@@ -36,6 +36,14 @@ config: |
     timeout client 60s
     timeout connect 60s
     timeout server 60s
+
+  # Allow Prometheus to scrape metrics.
+  # See: https://www.haproxy.com/documentation/haproxy-configuration-tutorials/alerts-and-monitoring/prometheus/
+  frontend prometheus
+    bind :8405
+    mode http
+    http-request use-service prometheus-exporter
+    no log
 
   frontend fe_main
     bind :80
@@ -111,13 +119,20 @@ args:
 
 service:
   type: NodePort
+
+  # Map each container port to a specific node port for external access (from
+  # outside the cluster). We do not intend to expose the Prometheus port, but
+  # Kubernetes will still map it to a random node port regardless.
   nodePorts:
     http: 30080
     dataplane: 30555
     stat: 31024
 
+# These ports will be automatically included in the service object and exposed
+# for external access (because we selected NodePort service type).
 containerPorts:
   http: 80
   https: 443
   stat: 1024
   dataplane: 5555
+  prometheus: 8405

--- a/k8s/charts/values-prometheus.yaml
+++ b/k8s/charts/values-prometheus.yaml
@@ -13,7 +13,7 @@ server:
 
   # Default metrics retention time is 15 days, but it is too large for the DFaaS
   # Agent's needs.
-  retention: "5d"
+  retention: "3d"
 
 serverFiles:
   alerting_rules.yml:


### PR DESCRIPTION
This pull request enables Prometheus to scrape metrics from HAProxy. Going forward, the idea is for the DFaaS agent to query metrics from Prometheus instead of directly from HAProxy (although some queries will still need to be made directly to HAProxy). One main advantage is that external components or users can now query Prometheus, which can help with debugging and developing load-balancing strategies.